### PR TITLE
feat: load fonts from fontsource packages

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,8 @@
     "": {
       "name": "cetus",
       "dependencies": {
+        "@fontsource-variable/inter": "^5.2.6",
+        "@fontsource-variable/outfit": "^5.2.6",
         "@hookform/resolvers": "^5.2.1",
         "@microsoft/signalr": "^9.0.6",
         "@radix-ui/react-alert-dialog": "^1.1.14",
@@ -273,6 +275,10 @@
     "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.2", "", { "dependencies": { "@floating-ui/dom": "^1.0.0" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A=="],
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.9", "", {}, "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg=="],
+
+    "@fontsource-variable/inter": ["@fontsource-variable/inter@5.2.6", "", {}, "sha512-jks/bficUPQ9nn7GvXvHtlQIPudW7Wx8CrlZoY8bhxgeobNxlQan8DclUJuYF2loYRrGpfrhCIZZspXYysiVGg=="],
+
+    "@fontsource-variable/outfit": ["@fontsource-variable/outfit@5.2.6", "", {}, "sha512-0wNlmsinE4taUgmRySxld13//NtnGwN58mBegexyhYuFqiQG/4Ho+5CCkiFxXijnojmCiaBaKkYt72LDwZHiKg=="],
 
     "@formatjs/ecma402-abstract": ["@formatjs/ecma402-abstract@2.3.3", "", { "dependencies": { "@formatjs/fast-memoize": "2.2.6", "@formatjs/intl-localematcher": "0.6.0", "decimal.js": "10", "tslib": "2" } }, "sha512-pJT1OkhplSmvvr6i3CWTPvC/FGC06MbN5TNBfRO6Ox62AEz90eMq+dVvtX9Bl3jxCEkS0tATzDarRZuOLw7oFg=="],
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "auth:generate": "npx @better-auth/cli generate --config src/server/auth.ts"
   },
   "dependencies": {
+    "@fontsource-variable/inter": "^5.2.6",
+    "@fontsource-variable/outfit": "^5.2.6",
     "@hookform/resolvers": "^5.2.1",
     "@microsoft/signalr": "^9.0.6",
     "@radix-ui/react-alert-dialog": "^1.1.14",

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -16,6 +16,9 @@ import { PostHogProvider } from 'posthog-js/react'
 import type { ReactNode } from 'react'
 import { I18nProvider } from 'react-aria'
 
+import '@fontsource-variable/inter'
+import '@fontsource-variable/outfit'
+
 type RouterContext = {
   queryClient: QueryClient
 }
@@ -33,23 +36,7 @@ export const Route = createRootRouteWithContext<RouterContext>()({
         title: 'cetus',
       },
     ],
-    links: [
-      { rel: 'stylesheet', href: appCss },
-      { rel: 'preconnect', href: 'https://fonts.googleapis.com' },
-      {
-        rel: 'preconnect',
-        href: 'https://fonts.gstatic.com',
-        crossOrigin: 'anonymous',
-      },
-      {
-        rel: 'stylesheet',
-        href: 'https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap',
-      },
-      {
-        rel: 'stylesheet',
-        href: 'https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=Outfit:wght@100..900&display=swap',
-      },
-    ],
+    links: [{ rel: 'stylesheet', href: appCss }],
   }),
   notFoundComponent: () => <NotFound />,
   component: RootComponent,

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -194,10 +194,10 @@
   --red-alpha-10: #fb37481a;
 
   --font-sans:
-    "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+    "Inter Variable", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
 
   --font-heading:
-    "Outfit", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+    "Outfit Variable", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
 
   --font-mono:
     ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",


### PR DESCRIPTION
# Replace Google Fonts with Fontsource

This PR replaces Google Fonts with Fontsource packages for Inter and Outfit fonts. The changes:

- Add `@fontsource-variable/inter` and `@fontsource-variable/outfit` packages
- Import font packages directly in `__root.tsx`
- Remove Google Fonts links from the document head
- Update font family references in CSS to use the new font names

This approach improves performance by hosting fonts locally instead of loading them from Google's CDN.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Switched app typography to Inter Variable and Outfit Variable for smoother, more consistent text rendering.
  * Stopped loading fonts from external providers; fonts are now bundled with the app, improving privacy and initial load reliability.

* **Chores**
  * Added bundled variable font packages to support the new typography.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->